### PR TITLE
Implement in-house DB to avoid repetitive calls (Part-1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ btree-map = "0.1.0"
 quicli = "0.4.0"
 structopt = "0.3.26"
 linecount = "0.1.0"
+serde_json = "1.0.99"
+serde = { version = "1.0.164", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ structopt = "0.3.26"
 linecount = "0.1.0"
 serde_json = "1.0.99"
 serde = { version = "1.0.164", features = ["derive"] }
+simple-home-dir = "0.1.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,1 +1,3 @@
 pub const LAST_MANY_COMMIT_HASHES: i32 = 5;
+pub const AUTHOR_DB_PATH: &str = "db_author.json";
+pub const FILE_DB_PATH: &str = "db_file.json";

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
 pub const LAST_MANY_COMMIT_HASHES: i32 = 5;
 pub const AUTHOR_DB_PATH: &str = "db_author.json";
 pub const FILE_DB_PATH: &str = "db_file.json";
+pub const DB_FOLDER: &str = ".context_pilot_db";

--- a/src/contextgpt_structs.rs
+++ b/src/contextgpt_structs.rs
@@ -1,4 +1,5 @@
 use structopt::StructOpt;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, StructOpt)]
 pub struct Cli {
@@ -13,7 +14,7 @@ pub struct Cli {
     pub request_type: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct AuthorDetails {
     pub commit_hash: String,
     pub author_full_name: String,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,70 @@
+use std::{
+    collections::HashMap,
+    fs::{write, File},
+    io::{Read, Write},
+    path::Path,
+};
+
+use crate::{config, contextgpt_structs::AuthorDetails};
+
+#[derive(Default)]
+pub struct DB {
+    pub db_file_path: String,
+    pub current_data: HashMap<String, Vec<AuthorDetails>>,
+}
+
+impl DB {
+    pub fn read(&mut self, file_obj: &mut File) -> HashMap<String, Vec<AuthorDetails>> {
+        let data_buffer = std::fs::read_to_string(self.db_file_path.clone()).unwrap();
+        let v: HashMap<String, Vec<AuthorDetails>> = serde_json::from_str(&data_buffer.as_str())
+            .expect("Unable to deserialize the file, something went wrong");
+        v
+    }
+
+    pub fn init_db(&mut self) {
+        let db_path_obj: &Path = Path::new(&self.db_file_path);
+        if !db_path_obj.exists() {
+            File::create(db_path_obj).expect("Couldn't create the file for some reason");
+            self.current_data = HashMap::new();
+            return;
+        }
+        let mut file_obj =
+            File::open(self.db_file_path.as_str()).expect("Couldn't open the given file");
+        self.current_data = self.read(&mut file_obj);
+    }
+
+    pub fn append(&mut self, configured_file_path: &String, data: AuthorDetails) {
+        let mut existing_data = vec![];
+        if self.current_data.contains_key(configured_file_path) {
+            existing_data = self
+                .current_data
+                .get_mut(configured_file_path)
+                .unwrap()
+                .to_vec();
+            existing_data.append(&mut vec![data]);
+        } else {
+            existing_data.append(&mut vec![data]);
+        }
+        self.current_data
+            .insert(configured_file_path.to_string(), existing_data);
+    }
+
+    pub fn store(&mut self) {
+        let mut file_obj =
+            File::create(self.db_file_path.as_str()).expect("Couldn't open the given file");
+        let output_string =
+            serde_json::to_string_pretty(&self.current_data).expect("Unable to write data");
+        // file_obj
+        //     .write_all(output_string.as_bytes())
+        //     .expect("Unable to write bytes to the file");
+        write!(file_obj, "{}", output_string).expect("Couldn't write, uhmmm");
+    }
+
+    pub fn exists(&self, search_field: &String) -> Option<&Vec<AuthorDetails>> {
+        if self.current_data.contains_key(search_field) {
+            self.current_data.get(search_field)
+        } else {
+            None
+        }
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,8 +9,9 @@ use crate::{config, contextgpt_structs::AuthorDetails};
 
 #[derive(Default)]
 pub struct DB {
-    pub db_file_path: String,
+    pub db_file_name: String,
     pub current_data: HashMap<String, Vec<AuthorDetails>>,
+    pub db_file_path: String,
 }
 
 impl DB {
@@ -22,6 +23,16 @@ impl DB {
     }
 
     pub fn init_db(&mut self) {
+        let folder_path = Path::new(simple_home_dir::home_dir().unwrap().to_str().unwrap())
+            .join(config::DB_FOLDER);
+        self.db_file_path = folder_path
+            .join(&self.db_file_name)
+            .to_str()
+            .unwrap()
+            .to_string();
+        // Create folder
+        std::fs::create_dir_all(folder_path)
+            .expect("unable to create folder, something went wrong");
         let db_path_obj: &Path = Path::new(&self.db_file_path);
         if !db_path_obj.exists() {
             File::create(db_path_obj).expect("Couldn't create the file for some reason");

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,11 @@ fn main() -> CliResult {
         end_line_number
     };
     let mut auth_db_obj = db::DB {
-        db_file_path: config::AUTHOR_DB_PATH.to_string(),
+        db_file_name: config::AUTHOR_DB_PATH.to_string(),
         ..Default::default()
     };
     let mut file_db_obj = db::DB {
-        db_file_path: config::FILE_DB_PATH.to_string(),
+        db_file_name: config::FILE_DB_PATH.to_string(),
         ..Default::default()
     };
     if args.request_type.starts_with("aut") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod algo_loc;
 mod authordetails_impl;
 mod config;
 mod contextgpt_structs;
+mod db;
 
 use linecount::count_lines;
 use quicli::prelude::*;
@@ -29,11 +30,31 @@ fn main() -> CliResult {
     } else {
         end_line_number
     };
+    let mut auth_db_obj = db::DB {
+        db_file_path: config::AUTHOR_DB_PATH.to_string(),
+        ..Default::default()
+    };
+    let mut file_db_obj = db::DB {
+        db_file_path: config::FILE_DB_PATH.to_string(),
+        ..Default::default()
+    };
     if args.request_type.starts_with("aut") {
-        let output = get_contextual_authors(args.file, args.start_number, valid_end_line_number);
+        auth_db_obj.init_db();
+        let output = get_contextual_authors(
+            args.file,
+            args.start_number,
+            valid_end_line_number,
+            &mut auth_db_obj,
+        );
         println!("{:?}", output);
     } else {
-        let output = get_unique_files_changed(args.file, args.start_number, valid_end_line_number);
+        file_db_obj.init_db();
+        let output = get_unique_files_changed(
+            args.file,
+            args.start_number,
+            valid_end_line_number,
+            &mut file_db_obj,
+        );
         println!("{:?}", output);
     }
     Ok(())


### PR DESCRIPTION
Notes for Part-2:

1. Split JSON files to avoid loading a huge file and JSON object at once.
2. Rethink the schema of JSON for files mode.
3. Testing