### PR TITLE
Update DB schema and add support for overlapping

### DIFF
--- a/src/algo_loc.rs
+++ b/src/algo_loc.rs
@@ -90,10 +90,7 @@ pub fn get_contextual_authors(
         if res.ends_with(',') {
             res.pop();
         }
-        if search_field_second.is_empty() {
-            println!("Found empty, returning...");
-            return res;
-        } else {
+        if !search_field_second.is_empty() {
             // find if multiple splits are there
             let split_search_field: Vec<&str> = search_field_second.split('_').collect();
             if split_search_field.len() == 4 {

--- a/src/algo_loc.rs
+++ b/src/algo_loc.rs
@@ -69,8 +69,7 @@ pub fn get_contextual_authors(
     end_line_number: usize,
     db_obj: &mut DB,
 ) -> String {
-    let configured_file_path: String =
-        format!("{file_path}**{start_line_number}**{end_line_number}");
+    let configured_file_path: String = file_path.clone();
     let line_str: String = format!("{start_line_number}_{end_line_number}");
     // Check in the DB first
     let mut res = String::new();
@@ -92,6 +91,7 @@ pub fn get_contextual_authors(
             res.pop();
         }
         if search_field_second.is_empty() {
+            println!("Found empty, returning...");
             return res;
         } else {
             // find if multiple splits are there

--- a/src/db.rs
+++ b/src/db.rs
@@ -51,25 +51,19 @@ impl DB {
             let file_data = self.current_data.get_mut(configured_file_path).unwrap();
             if !file_data.contains_key(&line_str) {
                 file_data.insert(line_str.clone(), vec![data]);
-                return;
             } else {
                 file_data
                     .get_mut(&line_str)
                     .unwrap()
-                    .append(&mut vec![data.clone()]);
-                return;
+                    .append(&mut vec![data]);
             }
         } else {
             existing_data.append(&mut vec![data]);
             let mut map = HashMap::new();
-            map.insert(line_str, existing_data).unwrap();
+            map.insert(line_str, existing_data);
             self.current_data
                 .insert(configured_file_path.to_string(), map);
         }
-        // self.current_data
-        //     .get_mut(configured_file_path)
-        //     .unwrap()
-        //     .insert(line_str, existing_data);
     }
 
     pub fn store(&mut self) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -48,24 +48,28 @@ impl DB {
         let mut existing_data = vec![];
         let line_str: String = format!("{start_line_number}_{end_line_number}");
         if self.current_data.contains_key(configured_file_path) {
-            let existing_data = self
-                .current_data
-                .get_mut(configured_file_path)
-                .unwrap();
-            if !existing_data.contains_key(&line_str) {
-                existing_data.insert(line_str.clone(), vec![data]);
+            let file_data = self.current_data.get_mut(configured_file_path).unwrap();
+            if !file_data.contains_key(&line_str) {
+                file_data.insert(line_str.clone(), vec![data]);
+                return;
             } else {
-                existing_data.get_mut(&line_str).unwrap().append(&mut vec![data]);
+                file_data
+                    .get_mut(&line_str)
+                    .unwrap()
+                    .append(&mut vec![data.clone()]);
+                return;
             }
         } else {
             existing_data.append(&mut vec![data]);
+            let mut map = HashMap::new();
+            map.insert(line_str, existing_data).unwrap();
             self.current_data
-                .insert(configured_file_path.to_string(), HashMap::new());
+                .insert(configured_file_path.to_string(), map);
         }
-        self.current_data
-            .get_mut(configured_file_path)
-            .unwrap()
-            .insert(line_str, existing_data);
+        // self.current_data
+        //     .get_mut(configured_file_path)
+        //     .unwrap()
+        //     .insert(line_str, existing_data);
     }
 
     pub fn store(&mut self) {
@@ -120,10 +124,10 @@ impl DB {
                             }
                             output_vec = Some(final_data);
                             output_string = "".to_string();
-                        } else if start_line_number >= received_end_line_number {
+                        } else if start_line_number > received_end_line_number {
                             output_vec = None;
                             output_string = search_field_second.to_string();
-                        }else if start_line_number >= received_start_line_number
+                        } else if start_line_number >= received_start_line_number
                         // && end_line_number > received_start_line_number
                         {
                             let full_data = existing_lines.get(each_key_combination).unwrap();
@@ -163,13 +167,11 @@ impl DB {
                             output_string = search_field_second.to_string();
                         }
                     }
-                    // println!("output vec stirng: {:?}, {:?}", output_vec, output_string);
                     (output_vec, output_string)
                 }
                 _ => (None, search_field_second.to_string()),
             }
         } else {
-            // println!("None**2 output vec stirng");
             (None, search_field_second.to_string())
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod contextgpt_structs;
 mod db;
 mod git_command_algo;
+mod collisions;
 
 use linecount::count_lines;
 use quicli::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod config;
 mod contextgpt_structs;
 mod db;
 mod git_command_algo;
-mod collisions;
 
 use linecount::count_lines;
 use quicli::prelude::*;


### PR DESCRIPTION
The new schema looks like:

```
file_path: {
    "<start_line_number>_<end_line_number>": [....],
}
```

Overlapping support:

Imagine a scenario where user makes query for 2nd line to 100th line - the server should process it and return the result. But next time, if the user queries for 3rd to 103rd line - the server *ideally* should just process for 101st, 102nd, and 103rd lines and everything else should be fetched from the DB for 2nd to 100th line. This PR addresses exactly that, and it's fixed now.

I'm hesitant to release this right now, as the code is not tested and this is a big change. But... still thinking :)