### PR TITLE
Major revision: DB now contains per line indices, no overlapping needed

### DIFF
--- a/src/algo_loc.rs
+++ b/src/algo_loc.rs
@@ -68,10 +68,10 @@ pub fn perform_for_single_line(
     is_author_mode: bool,
 ) -> String {
     let output = extract_details(start_line_number, end_line_number, origin_file_path.clone());
-    println!(
-        "Only computing for {:?} -> {:?}",
-        start_line_number, end_line_number
-    );
+    // println!(
+    //     "Only computing for {:?} -> {:?}",
+    //     start_line_number, end_line_number
+    // );
     let mut res: HashMap<String, usize> = HashMap::new();
     db_obj.append(
         &origin_file_path,

--- a/src/algo_loc.rs
+++ b/src/algo_loc.rs
@@ -4,81 +4,98 @@ use std::collections::HashMap;
 
 pub fn get_unique_files_changed(
     origin_file_path: String,
-    start_line_number: usize,
-    end_line_number: usize,
+    start_line_number: &usize,
+    end_line_number: &usize,
     db_obj: &mut DB,
 ) -> String {
-    let configured_file_path: String = origin_file_path.clone();
-    let line_str: String = format!("{start_line_number}_{end_line_number}");
     // Check in the DB first
     let mut res = String::new();
     let mut visited: HashMap<String, usize> = HashMap::new();
-    if let (Some(obj), search_field_second) = db_obj.exists(&configured_file_path, &line_str) {
-        // means nothing to do...
-        for author_detail in obj {
-            for each_file in author_detail.contextual_file_paths.clone() {
-                if visited.contains_key(&each_file) {
-                    continue;
+    let (existing_result_optional, unvisited_indices) =
+        db_obj.exists_and_return(&origin_file_path, start_line_number, end_line_number);
+    match existing_result_optional {
+        Some(existing_result) => {
+            for author_detail in existing_result {
+                for each_file in author_detail.contextual_file_paths.clone() {
+                    if visited.contains_key(&each_file) {
+                        continue;
+                    }
+                    visited.insert(each_file.clone(), 1);
+                    res.push_str(&each_file);
+                    res.push(',');
                 }
-                visited.insert(each_file.clone(), 1);
-                res.push_str(&each_file);
-                res.push(',');
             }
+            if res.ends_with(',') {
+                res.pop();
+            }
+            if !unvisited_indices.is_empty() {
+                // find if multiple splits are there
+                let mut res_string: String = res;
+                for each_unvisited_index in unvisited_indices {
+                    res_string += &perform_for_single_line(
+                        each_unvisited_index,
+                        each_unvisited_index,
+                        origin_file_path.clone(),
+                        db_obj,
+                        false,
+                    );
+                }
+                return res_string;
+            }
+            res
         }
-        if res.ends_with(',') {
-            res.pop();
-        }
-        if !search_field_second.is_empty() {
-            // find if multiple splits are there
-            let split_search_field: Vec<&str> = search_field_second.split('_').collect();
-            if split_search_field.len() == 4 {
-                let start_line_number: usize = split_search_field.first().unwrap().parse().unwrap();
-                let end_line_number: usize = split_search_field.get(1).unwrap().parse().unwrap();
-                let output = get_unique_files_changed(
+        None => {
+            let mut final_result = "".to_string();
+            for each_unvisited_index in unvisited_indices {
+                final_result += &perform_for_single_line(
+                    each_unvisited_index,
+                    each_unvisited_index,
                     origin_file_path.clone(),
-                    start_line_number,
-                    end_line_number,
                     db_obj,
-                );
-                let start_line_number: usize = split_search_field.get(2).unwrap().parse().unwrap();
-                let end_line_number: usize = split_search_field.get(3).unwrap().parse().unwrap();
-                let output_second = get_unique_files_changed(
-                    origin_file_path,
-                    start_line_number,
-                    end_line_number,
-                    db_obj,
-                );
-                return output + &output_second;
-            } else {
-                let start_line_number: usize = split_search_field.first().unwrap().parse().unwrap();
-                let end_line_number: usize = split_search_field.get(1).unwrap().parse().unwrap();
-                return get_unique_files_changed(
-                    origin_file_path,
-                    start_line_number,
-                    end_line_number,
-                    db_obj,
+                    false,
                 );
             }
-        } else {
-            return res;
+            final_result
         }
     }
-    let output = extract_details(start_line_number, end_line_number, origin_file_path);
+}
+
+pub fn perform_for_single_line(
+    start_line_number: usize,
+    end_line_number: usize,
+    origin_file_path: String,
+    db_obj: &mut DB,
+    is_author_mode: bool,
+) -> String {
+    let output = extract_details(start_line_number, end_line_number, origin_file_path.clone());
+    println!(
+        "Only computing for {:?} -> {:?}",
+        start_line_number, end_line_number
+    );
     let mut res: HashMap<String, usize> = HashMap::new();
+    db_obj.append(
+        &origin_file_path,
+        start_line_number,
+        end_line_number,
+        output.clone(),
+    );
     for single_struct in output {
-        db_obj.append(
-            &configured_file_path,
-            start_line_number,
-            end_line_number,
-            single_struct.clone(),
-        );
-        for each_file in single_struct.contextual_file_paths {
-            if res.contains_key(&each_file) {
-                let count = res.get(&each_file).unwrap() + 1;
-                res.insert(each_file, count);
+        if is_author_mode {
+            if res.contains_key(&single_struct.author_full_name) {
+                let count = res.get(&single_struct.author_full_name).unwrap() + 1;
+                res.insert(single_struct.author_full_name, count);
                 continue;
             }
-            res.insert(each_file, 0);
+            res.insert(single_struct.author_full_name, 0);
+        } else {
+            for each_file in single_struct.contextual_file_paths {
+                if res.contains_key(&each_file) {
+                    let count = res.get(&each_file).unwrap() + 1;
+                    res.insert(each_file, count);
+                    continue;
+                }
+                res.insert(each_file, 0);
+            }
         }
     }
     db_obj.store();
@@ -94,88 +111,60 @@ pub fn get_unique_files_changed(
 }
 
 pub fn get_contextual_authors(
-    file_path: String,
-    start_line_number: usize,
-    end_line_number: usize,
+    origin_file_path: String,
+    start_line_number: &usize,
+    end_line_number: &usize,
     db_obj: &mut DB,
 ) -> String {
-    let configured_file_path: String = file_path.clone();
-    let line_str: String = format!("{start_line_number}_{end_line_number}");
     // Check in the DB first
     let mut res = String::new();
     let mut visited: HashMap<String, usize> = HashMap::new();
-    if let (Some(obj), search_field_second) = db_obj.exists(&configured_file_path, &line_str) {
-        // means nothing to do...
-        for author_detail in obj {
-            if visited.contains_key(&author_detail.author_full_name) {
-                continue;
+    let (existing_result_optional, unvisited_indices) =
+        db_obj.exists_and_return(&origin_file_path, start_line_number, end_line_number);
+    match existing_result_optional {
+        Some(existing_result) => {
+            for author_detail in existing_result {
+                if visited.contains_key(&author_detail.author_full_name) {
+                    continue;
+                }
+                if author_detail.author_full_name.contains("Not Committed Yet") {
+                    continue;
+                }
+                visited.insert(author_detail.author_full_name.clone(), 1);
+                res.push_str(&author_detail.author_full_name);
+                res.push(',');
             }
-            if author_detail.author_full_name.contains("Not Committed Yet") {
-                continue;
+            if res.ends_with(',') {
+                res.pop();
             }
-            visited.insert(author_detail.author_full_name.clone(), 1);
-            res.push_str(&author_detail.author_full_name);
-            res.push(',');
+            if !unvisited_indices.is_empty() {
+                // find if multiple splits are there
+                let mut res_string: String = res;
+                for each_unvisited_index in unvisited_indices {
+                    res_string += &perform_for_single_line(
+                        each_unvisited_index,
+                        each_unvisited_index,
+                        origin_file_path.clone(),
+                        db_obj,
+                        true,
+                    );
+                }
+                return res_string;
+            }
+            res
         }
-        if res.ends_with(',') {
-            res.pop();
-        }
-        if !search_field_second.is_empty() {
-            // find if multiple splits are there
-            let split_search_field: Vec<&str> = search_field_second.split('_').collect();
-            if split_search_field.len() == 4 {
-                let start_line_number: usize = split_search_field.first().unwrap().parse().unwrap();
-                let end_line_number: usize = split_search_field.get(1).unwrap().parse().unwrap();
-                let output = get_contextual_authors(
-                    file_path.clone(),
-                    start_line_number,
-                    end_line_number,
+        None => {
+            let mut final_result = "".to_string();
+            for each_unvisited_index in unvisited_indices {
+                final_result += &perform_for_single_line(
+                    each_unvisited_index,
+                    each_unvisited_index,
+                    origin_file_path.clone(),
                     db_obj,
-                );
-                let start_line_number: usize = split_search_field.get(2).unwrap().parse().unwrap();
-                let end_line_number: usize = split_search_field.get(3).unwrap().parse().unwrap();
-                let output_second =
-                    get_contextual_authors(file_path, start_line_number, end_line_number, db_obj);
-                return output + &output_second;
-            } else {
-                let start_line_number: usize = split_search_field.first().unwrap().parse().unwrap();
-                let end_line_number: usize = split_search_field.get(1).unwrap().parse().unwrap();
-                return get_contextual_authors(
-                    file_path,
-                    start_line_number,
-                    end_line_number,
-                    db_obj,
+                    true,
                 );
             }
-        } else {
-            return res;
+            final_result
         }
     }
-    let output = extract_details(start_line_number, end_line_number, file_path);
-    let mut res: HashMap<String, usize> = HashMap::new();
-    for single_struct in output {
-        db_obj.append(
-            &configured_file_path,
-            start_line_number,
-            end_line_number,
-            single_struct.clone(),
-        );
-        let author_full_name = single_struct.author_full_name;
-        if res.contains_key(&author_full_name) {
-            let count = res.get(&author_full_name).unwrap() + 1;
-            res.insert(author_full_name, count);
-            continue;
-        }
-        res.insert(author_full_name, 0);
-    }
-    db_obj.store();
-    let mut res_string: String = String::new();
-    for key in res.keys() {
-        res_string.push_str(key.as_str());
-        res_string.push(',');
-    }
-    if res_string.ends_with(',') {
-        res_string.pop();
-    }
-    res_string
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,14 +5,14 @@ use crate::{config, contextgpt_structs::AuthorDetails};
 #[derive(Default)]
 pub struct DB {
     pub db_file_name: String,
-    pub current_data: HashMap<String, HashMap<String, Vec<AuthorDetails>>>,
+    pub current_data: HashMap<String, HashMap<usize, Vec<AuthorDetails>>>,
     pub db_file_path: String,
 }
 
 impl DB {
-    pub fn read(&mut self) -> HashMap<String, HashMap<String, Vec<AuthorDetails>>> {
+    pub fn read(&mut self) -> HashMap<String, HashMap<usize, Vec<AuthorDetails>>> {
         let data_buffer = std::fs::read_to_string(self.db_file_path.clone()).unwrap();
-        let v: HashMap<String, HashMap<String, Vec<AuthorDetails>>> =
+        let v: HashMap<String, HashMap<usize, Vec<AuthorDetails>>> =
             serde_json::from_str(data_buffer.as_str())
                 .expect("Unable to deserialize the file, something went wrong");
         v
@@ -41,28 +41,32 @@ impl DB {
     pub fn append(
         &mut self,
         configured_file_path: &String,
-        start_line_number: usize,
-        end_line_number: usize,
-        data: AuthorDetails,
+        start_line_idx: usize,
+        end_line_idx: usize,
+        all_data: Vec<AuthorDetails>,
     ) {
-        let mut existing_data = vec![];
-        let line_str: String = format!("{start_line_number}_{end_line_number}");
-        if self.current_data.contains_key(configured_file_path) {
-            let file_data = self.current_data.get_mut(configured_file_path).unwrap();
-            if !file_data.contains_key(&line_str) {
-                file_data.insert(line_str.clone(), vec![data]);
+        for line_idx in start_line_idx..end_line_idx + 1 {
+            let mut existing_data = vec![];
+            if self.current_data.contains_key(configured_file_path) {
+                let file_data = self.current_data.get_mut(configured_file_path).unwrap();
+                match file_data.contains_key(&line_idx) {
+                    false => {
+                        file_data.insert(line_idx, all_data.clone());
+                    }
+                    true => {
+                        file_data
+                            .get_mut(&line_idx)
+                            .unwrap()
+                            .append(&mut all_data.clone());
+                    }
+                }
             } else {
-                file_data
-                    .get_mut(&line_str)
-                    .unwrap()
-                    .append(&mut vec![data]);
+                existing_data.extend(all_data.clone());
+                let mut map = HashMap::new();
+                map.insert(line_idx, existing_data);
+                self.current_data
+                    .insert(configured_file_path.to_string(), map);
             }
-        } else {
-            existing_data.append(&mut vec![data]);
-            let mut map = HashMap::new();
-            map.insert(line_str, existing_data);
-            self.current_data
-                .insert(configured_file_path.to_string(), map);
         }
     }
 
@@ -74,99 +78,35 @@ impl DB {
         write!(file_obj, "{}", output_string).expect("Couldn't write, uhmmm");
     }
 
-    pub fn exists(
-        &self,
+    pub fn exists_and_return(
+        &mut self,
         search_field_first: &String,
-        search_field_second: &String,
-    ) -> (Option<Vec<AuthorDetails>>, String) {
+        start_line_number: &usize,
+        end_line_number: &usize,
+    ) -> (Option<Vec<&AuthorDetails>>, Vec<usize>) {
+        let mut already_computed_data: Vec<&AuthorDetails> = vec![];
+        let mut uncovered_indices: Vec<usize> = vec![];
         if self.current_data.contains_key(search_field_first) {
-            let line_numbers: Vec<&str> = search_field_second.split('_').collect();
-            let start_line_number: usize = line_numbers.first().unwrap().parse().unwrap();
-            let end_line_number: usize = line_numbers.last().unwrap().parse().unwrap();
-            let file_searched = self.current_data.get(search_field_first);
-            match file_searched {
-                Some(existing_lines) => {
-                    let keys = existing_lines.keys();
-                    if keys.len() == 0 {
-                        return (None, search_field_second.to_string());
+            let output = self.current_data.get_mut(search_field_first);
+            if let Some(all_line_data) = output {
+                for each_line_idx in *start_line_number..*end_line_number+1 {
+                    if let Some(eligible_data) = all_line_data.get(&each_line_idx) {
+                        already_computed_data.extend(eligible_data);
+                    } else {
+                        uncovered_indices.push(each_line_idx);
                     }
-                    let mut output_vec = None;
-                    let mut output_string = "".to_string();
-                    for each_key_combination in keys {
-                        let line_numbers: Vec<&str> = each_key_combination.split('_').collect();
-                        let received_start_line_number: usize =
-                            line_numbers.first().unwrap().parse().unwrap();
-                        let received_end_line_number: usize =
-                            line_numbers.last().unwrap().parse().unwrap();
-                        if start_line_number == received_start_line_number
-                            && end_line_number == received_end_line_number
-                        {
-                            output_vec = existing_lines.get(each_key_combination).cloned();
-                            output_string = "".to_string();
-                        } else if start_line_number >= received_start_line_number
-                            && end_line_number <= received_end_line_number
-                        {
-                            // in between
-                            let full_data = existing_lines.get(each_key_combination).unwrap();
-                            let mut final_data: Vec<AuthorDetails> = Vec::new();
-                            for line_data in full_data {
-                                if line_data.line_number >= start_line_number
-                                    && line_data.line_number <= end_line_number
-                                {
-                                    final_data.push(line_data.clone());
-                                }
-                            }
-                            output_vec = Some(final_data);
-                            output_string = "".to_string();
-                        } else if start_line_number > received_end_line_number {
-                            output_vec = None;
-                            output_string = search_field_second.to_string();
-                        } else if start_line_number >= received_start_line_number
-                        // && end_line_number > received_start_line_number
-                        {
-                            let full_data = existing_lines.get(each_key_combination).unwrap();
-                            let mut final_data: Vec<AuthorDetails> = Vec::new();
-                            for line_data in full_data {
-                                if line_data.line_number >= start_line_number
-                                    && line_data.line_number <= received_end_line_number
-                                {
-                                    final_data.push(line_data.clone());
-                                }
-                            }
-                            output_vec = Some(final_data);
-                            let final_start_line_number = received_end_line_number + 1;
-                            output_string = format!("{final_start_line_number}_{end_line_number}");
-                        } else if start_line_number <= received_start_line_number
-                            && end_line_number >= received_start_line_number
-                        {
-                            let full_data = existing_lines.get(each_key_combination).unwrap();
-                            let mut final_data: Vec<AuthorDetails> = Vec::new();
-                            for line_data in full_data {
-                                if line_data.line_number >= received_start_line_number
-                                    && line_data.line_number <= end_line_number
-                                {
-                                    final_data.push(line_data.clone());
-                                }
-                            }
-                            output_vec = Some(final_data);
-                            if end_line_number > received_end_line_number {
-                                let final_received_end_line_number = received_end_line_number + 1;
-                                output_string = format!("{start_line_number}_{received_start_line_number}_{final_received_end_line_number}_{end_line_number}");
-                            } else {
-                                output_string =
-                                    format!("{start_line_number}_{received_start_line_number}");
-                            }
-                        } else {
-                            output_vec = None;
-                            output_string = search_field_second.to_string();
-                        }
-                    }
-                    (output_vec, output_string)
                 }
-                _ => (None, search_field_second.to_string()),
+            }
+            if already_computed_data.is_empty() {
+                (None, uncovered_indices)
+            } else {
+                (Some(already_computed_data), uncovered_indices)
             }
         } else {
-            (None, search_field_second.to_string())
+            for idx in *start_line_number..*end_line_number+1 {
+                uncovered_indices.push(idx);
+            }
+            (None, uncovered_indices)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ fn main() -> CliResult {
         auth_db_obj.init_db();
         let output = get_contextual_authors(
             args.file,
-            args.start_number,
-            valid_end_line_number,
+            &args.start_number,
+            &valid_end_line_number,
             &mut auth_db_obj,
         );
         println!("{:?}", output);
@@ -52,8 +52,8 @@ fn main() -> CliResult {
         file_db_obj.init_db();
         let output = get_unique_files_changed(
             args.file,
-            args.start_number,
-            valid_end_line_number,
+            &args.start_number,
+            &valid_end_line_number,
             &mut file_db_obj,
         );
         println!("{:?}", output);


### PR DESCRIPTION
No overlapping from now on, store DB such as:

```
"file_path": {
    "0": [....],
    "2": [....],
}
```

Much faster this way, and cleaner.