### PR TITLE
Refactor: make sure to get mapping after the result

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,3 +2,5 @@ pub const LAST_MANY_COMMIT_HASHES: i32 = 5;
 pub const AUTHOR_DB_PATH: &str = "db_common.json";
 pub const FILE_DB_PATH: &str = "db_common.json";
 pub const DB_FOLDER: &str = ".context_pilot_db";
+// pub const FILE_COUNT_THRESHOLD: usize = 5;
+// pub const RETURN_COUNT: usize = 5;

--- a/src/contextgpt_structs.rs
+++ b/src/contextgpt_structs.rs
@@ -1,5 +1,5 @@
-use structopt::StructOpt;
 use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Cli {

--- a/src/git_command_algo.rs
+++ b/src/git_command_algo.rs
@@ -156,7 +156,12 @@ pub fn extract_details(
                     }
                     all_files_changed.push(each_file);
                 }
-                all_files_changed.extend(all_files_changed_initial_commit.clone());
+                for each_initial_commit_file in all_files_changed_initial_commit.clone() {
+                    if all_files_changed.contains(&each_initial_commit_file) {
+                        continue;
+                    }
+                    all_files_changed.push(each_initial_commit_file);
+                }
                 to_append_struct.contextual_file_paths = all_files_changed;
                 result_author_details.push(to_append_struct);
             }


### PR DESCRIPTION
Later on, we want to have a threshold on number of times an author/file occured, so that the results are cleaner and it gives user a confidence.