### PR TITLE
Convert request_type option in CLI to Enum

### DIFF
--- a/src/contextgpt_structs.rs
+++ b/src/contextgpt_structs.rs
@@ -1,5 +1,27 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use structopt::StructOpt;
+
+#[derive(Debug)]
+pub enum RequestTypeOptions {
+    Author,
+    File,
+}
+
+impl FromStr for RequestTypeOptions {
+    type Err = String;
+    fn from_str(request_type: &str) -> Result<Self, Self::Err> {
+        match request_type {
+            "author" => Ok(RequestTypeOptions::Author),
+            "file" => Ok(RequestTypeOptions::File),
+            // TODO: Pass the request_type in this error
+            _ => Err(format!(
+                "Could not parse the request type: {}",
+                request_type
+            )),
+        }
+    }
+}
 
 #[derive(Debug, StructOpt)]
 pub struct Cli {
@@ -10,8 +32,10 @@ pub struct Cli {
     #[structopt(short = "e")]
     pub end_number: usize,
 
+    // TODO: Add instructions on what request_type could be
+    // TODO: Conver this from String to an Enum
     #[structopt(short = "t")]
-    pub request_type: String,
+    pub request_type: RequestTypeOptions,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]

--- a/src/contextgpt_structs.rs
+++ b/src/contextgpt_structs.rs
@@ -14,7 +14,6 @@ impl FromStr for RequestTypeOptions {
         match request_type {
             "author" => Ok(RequestTypeOptions::Author),
             "file" => Ok(RequestTypeOptions::File),
-            // TODO: Pass the request_type in this error
             _ => Err(format!(
                 "Could not parse the request type: {}",
                 request_type
@@ -33,7 +32,6 @@ pub struct Cli {
     pub end_number: usize,
 
     // TODO: Add instructions on what request_type could be
-    // TODO: Conver this from String to an Enum
     #[structopt(short = "t")]
     pub request_type: RequestTypeOptions,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use quicli::prelude::*;
 use structopt::StructOpt;
 
 use algo_loc::get_unique_files_changed;
-use contextgpt_structs::Cli;
+use contextgpt_structs::{Cli, RequestTypeOptions};
 
 use crate::algo_loc::get_contextual_authors;
 
@@ -39,24 +39,29 @@ fn main() -> CliResult {
         db_file_name: config::FILE_DB_PATH.to_string(),
         ..Default::default()
     };
-    if args.request_type.starts_with("aut") {
-        auth_db_obj.init_db();
-        let output = get_contextual_authors(
-            args.file,
-            &args.start_number,
-            &valid_end_line_number,
-            &mut auth_db_obj,
-        );
-        println!("{:?}", output);
-    } else {
-        file_db_obj.init_db();
-        let output = get_unique_files_changed(
-            args.file,
-            &args.start_number,
-            &valid_end_line_number,
-            &mut file_db_obj,
-        );
-        println!("{:?}", output);
-    }
+    // FIXME: This is a very bad way to handle request_type, ideally this should be an enum
+    // if args.request_type == RequestTypeOptions::Author {
+    match args.request_type {
+        RequestTypeOptions::File => {
+            file_db_obj.init_db();
+            let output = get_unique_files_changed(
+                args.file,
+                &args.start_number,
+                &valid_end_line_number,
+                &mut file_db_obj,
+            );
+            println!("{:?}", output);
+        }
+        RequestTypeOptions::Author => {
+            auth_db_obj.init_db();
+            let output = get_contextual_authors(
+                args.file,
+                &args.start_number,
+                &valid_end_line_number,
+                &mut auth_db_obj,
+            );
+            println!("{:?}", output);
+        }
+    };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,6 @@ fn main() -> CliResult {
         db_file_name: config::FILE_DB_PATH.to_string(),
         ..Default::default()
     };
-    // FIXME: This is a very bad way to handle request_type, ideally this should be an enum
-    // if args.request_type == RequestTypeOptions::Author {
     match args.request_type {
         RequestTypeOptions::File => {
             file_db_obj.init_db();


### PR DESCRIPTION
As per the title, as to me - Enum made more sense than having just a string. Also, it returns a nice error message.