### PR TITLE
Add support for file count threshold and commit hashes threshold

### DIFF
--- a/src/algo_loc.rs
+++ b/src/algo_loc.rs
@@ -1,4 +1,4 @@
-// use crate::db::DB;
+use crate::config_impl;
 use crate::db::DB;
 use crate::git_command_algo::extract_details;
 use std::collections::HashMap;
@@ -31,6 +31,7 @@ pub fn get_unique_files_changed(
     start_line_number: &usize,
     end_line_number: &usize,
     db_obj: &mut DB,
+    config_obj: &config_impl::Config,
 ) -> String {
     // Check in the DB first
     let mut res = String::new();
@@ -70,6 +71,7 @@ pub fn get_unique_files_changed(
                         origin_file_path.clone(),
                         db_obj,
                         false,
+                        config_obj,
                     );
                     split_output_and_create_map(
                         output_single_line,
@@ -81,9 +83,9 @@ pub fn get_unique_files_changed(
                 if res_string.ends_with(',') {
                     let _ = res_string.pop();
                 }
-                return res_string;
+                return config_impl::trim_result(res_string, config_obj.file_count_threshold);
             }
-            res
+            config_impl::trim_result(res, config_obj.file_count_threshold)
         }
         None => {
             let mut final_result = "".to_string();
@@ -95,6 +97,7 @@ pub fn get_unique_files_changed(
                     origin_file_path.clone(),
                     db_obj,
                     false,
+                    config_obj,
                 );
                 split_output_and_create_map(
                     output_single_line,
@@ -106,7 +109,7 @@ pub fn get_unique_files_changed(
             if final_result.ends_with(',') {
                 let _ = final_result.pop();
             }
-            final_result
+            config_impl::trim_result(final_result, config_obj.file_count_threshold)
         }
     }
 }
@@ -117,8 +120,14 @@ pub fn perform_for_single_line(
     origin_file_path: String,
     db_obj: &mut DB,
     is_author_mode: bool,
+    config_obj: &config_impl::Config,
 ) -> String {
-    let output = extract_details(start_line_number, end_line_number, origin_file_path.clone());
+    let output = extract_details(
+        start_line_number,
+        end_line_number,
+        origin_file_path.clone(),
+        config_obj,
+    );
     // println!(
     //     "Only computing for {:?} -> {:?}",
     //     start_line_number, end_line_number
@@ -164,6 +173,7 @@ pub fn get_contextual_authors(
     start_line_number: &usize,
     end_line_number: &usize,
     db_obj: &mut DB,
+    config_obj: &config_impl::Config,
 ) -> String {
     // Check in the DB first
     let mut res = String::new();
@@ -203,6 +213,7 @@ pub fn get_contextual_authors(
                         origin_file_path.clone(),
                         db_obj,
                         true,
+                        config_obj,
                     );
                     split_output_and_create_map(
                         output_single_line,
@@ -214,9 +225,9 @@ pub fn get_contextual_authors(
                 if res_string.ends_with(',') {
                     let _ = res_string.pop();
                 }
-                return res_string;
+                return config_impl::trim_result(res_string, config_obj.file_count_threshold);
             }
-            res
+            config_impl::trim_result(res, config_obj.file_count_threshold)
         }
         None => {
             let mut final_result = "".to_string();
@@ -227,6 +238,7 @@ pub fn get_contextual_authors(
                     origin_file_path.clone(),
                     db_obj,
                     true,
+                    config_obj,
                 );
                 split_output_and_create_map(
                     output_single_line,
@@ -238,7 +250,7 @@ pub fn get_contextual_authors(
             if final_result.ends_with(',') {
                 let _ = final_result.pop();
             }
-            final_result
+            config_impl::trim_result(final_result, config_obj.file_count_threshold)
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-pub const LAST_MANY_COMMIT_HASHES: i32 = 5;
+pub const LAST_MANY_COMMIT_HASHES: usize = 5;
 // pub const AUTHOR_DB_PATH: &str = "db_common.json";
 // pub const FILE_DB_PATH: &str = "db_common.json";
 pub const DB_FOLDER: &str = ".context_pilot_db";
@@ -6,4 +6,13 @@ pub const MAX_ITEMS_IN_EACH_DB_FILE: u32 = 30; // arbitrary number for each DB t
 
 // Some more flags we'll need in the future
 // pub const FILE_COUNT_THRESHOLD: usize = 5;
-// pub const RETURN_COUNT: usize = 5;
+
+// Maybe I would prefer Lua as we go ahead
+pub const CONFIG_FILE_NAME: &str = "context_pilot.json";
+
+// Default for the output to be shown in UI for selector
+// For both request types: file and author
+pub const OUTPUT_COUNT_THRESHOLD: usize = 2;
+
+
+// TODO: Implement threshold for confidence for relevance

--- a/src/config_impl.rs
+++ b/src/config_impl.rs
@@ -1,0 +1,82 @@
+use crate::config;
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct Config {
+    pub file_count_threshold: usize,
+    pub commit_hashes_threshold: usize, // TODO: Have a default value here later on
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            file_count_threshold: config::OUTPUT_COUNT_THRESHOLD,
+            commit_hashes_threshold: config::LAST_MANY_COMMIT_HASHES,
+        }
+    }
+}
+
+pub fn read_config(config_file_name: &str) -> Config {
+    let home_dir_path: PathBuf = simple_home_dir::home_dir().unwrap_or_default();
+    let joined_path = home_dir_path.join(config_file_name);
+    let config_file = File::open(joined_path.clone());
+
+    match config_file {
+        Ok(_) => {
+            let mut config_stream = serde_json::Deserializer::from_reader(config_file.unwrap());
+            // TODO: Fix the error handling and ensure users are able to watch logs for this
+            let config = Config::deserialize(&mut config_stream)
+                .expect("Expected config to be deserialized, probably the format is wrong");
+            config
+        }
+        Err(_) => {
+            // TODO: Add a log that you are using defaults
+            println!("Using default config");
+            println!("Config file not found at: {:?}", &joined_path);
+            Config::default()
+        }
+    }
+}
+
+pub fn trim_result(inp: String, threshold: usize) -> String {
+    // number of words in the string should not cross threshold
+    // just trim the string
+    let mut final_str: String = "".to_string();
+    let mut count: usize = 0;
+    for inp_word in inp.split(',') {
+        final_str.push_str(inp_word);
+        count += 1;
+        if count >= threshold {
+            break;
+        }
+        final_str.push(',');
+    }
+    final_str
+}
+
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_trim_result() {
+        let inp = "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z".to_string();
+        let threshold = 10;
+        let out = trim_result(inp, threshold);
+        assert_eq!(out, "a,b,c,d,e,f,g,h,i,j,k");
+    }
+
+    #[test]
+    fn test_trim_result_from_config() {
+        let inp = "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z".to_string();
+        let config_obj = Config {
+            file_count_threshold: 10,
+            commit_hashes_threshold: 10,
+        };
+        let out = trim_result(inp, config_obj.file_count_threshold);
+        assert_eq!("a,b,c,d,e,f,g,h,i,j,k", out);
+    }
+}

--- a/src/git_command_algo.rs
+++ b/src/git_command_algo.rs
@@ -1,9 +1,11 @@
+use crate::config_impl;
+
 use std::{
     path::Path,
     process::{Command, Stdio},
 };
 
-use crate::{config::LAST_MANY_COMMIT_HASHES, contextgpt_structs::AuthorDetails};
+use crate::contextgpt_structs::AuthorDetails;
 
 pub fn parse_str(input_str: &str, file_path: &str) -> Vec<AuthorDetails> {
     let mut author_details_vec: Vec<AuthorDetails> = vec![];
@@ -76,6 +78,7 @@ pub fn extract_details(
     start_line_number: usize,
     end_line_number: usize,
     file_path: String,
+    config_obj: &config_impl::Config,
 ) -> Vec<AuthorDetails> {
     let mut binding = Command::new("git");
     let command = binding.args([
@@ -112,8 +115,8 @@ pub fn extract_details(
             all_files_changed_initial_commit.push(each_file);
         }
 
-        let mut blame_count: i32 = 0;
-        while blame_count != LAST_MANY_COMMIT_HASHES {
+        let mut blame_count: usize = 0;
+        while blame_count != config_obj.commit_hashes_threshold {
             blame_count += 1;
             let line_string: String =
                 val.line_number.to_string() + &','.to_string() + &val.line_number.to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod algo_loc;
 mod authordetails_impl;
 mod config;
+mod config_impl;
 mod contextgpt_structs;
 mod db;
 mod git_command_algo;
@@ -35,6 +36,10 @@ fn main() -> CliResult {
         folder_path: args.folder_path,
         ..Default::default()
     };
+
+    // Read the config file and pass defaults
+    let config_obj: config_impl::Config = config_impl::read_config(config::CONFIG_FILE_NAME);
+
     match args.request_type {
         RequestTypeOptions::File => {
             db_obj.init_db(args.file.as_str());
@@ -43,6 +48,7 @@ fn main() -> CliResult {
                 &args.start_number,
                 &valid_end_line_number,
                 &mut db_obj,
+                &config_obj,
             );
             println!("{:?}", output);
         }
@@ -53,10 +59,10 @@ fn main() -> CliResult {
                 &args.start_number,
                 &valid_end_line_number,
                 &mut db_obj,
+                &config_obj,
             );
             println!("{:?}", output);
         }
     };
     Ok(())
 }
-


### PR DESCRIPTION
Whenever a user calls the command, before this commit - Context Pilot will return all the relevant files and run through the git commit hashes with threshold of 5.

After this commit, the users will have option to set the thresholds themselves in $HOME_DIR/context_pilot.json, if not present - we'll use the defaults (defined in `config.rs` file). A small TODO after this is to make sure that users are pointed for the invalid JSON file format and also they should be able to skip one of the variables that need to be defined.

Ideally, I'm planning to switch to Lua for the config file instead of JSON, for now this is fine.