### PR TITLE
Return commit URL as well as the output

### DIFF
--- a/src/git_command_algo.rs
+++ b/src/git_command_algo.rs
@@ -161,19 +161,52 @@ pub fn get_all_commits_for_file(file_path: String) -> Vec<String> {
     commits
 }
 
+
+fn get_commit_base_url() -> Option<String> {
+    if let Ok(output) = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+    {
+        if output.status.success() {
+            if let Ok(url) = String::from_utf8(output.stdout) {
+                let url = url.trim();
+                // Handle GitHub URLs (both HTTPS and SSH)
+                if url.starts_with("git@github.com:") {
+                    let path = url.strip_prefix("git@github.com:").unwrap();
+                    // Optionally strip ".git" if present
+                    let path = path.strip_suffix(".git").unwrap_or(path);
+                    return Some(format!("https://github.com/{}/commit/", path));
+                } else if url.starts_with("https://github.com/") {
+                    let path = url.strip_prefix("https://github.com/").unwrap();
+                    // Optionally strip ".git" if present
+                    let path = path.strip_suffix(".git").unwrap_or(path);
+                    return Some(format!("https://github.com/{}/commit/", path));
+                }
+            }
+        }
+    }
+    None
+}
+
 pub fn get_commit_descriptions(commit_hashes: Vec<String>) -> Vec<Vec<String>> {
     let mut output_vec = Vec::new();
     let mut visited_commits = HashSet::new();
+
+    let base_url = get_commit_base_url();
 
     for commit_hash in commit_hashes.iter() {
         if visited_commits.contains(commit_hash) {
             continue;
         }
-        // First get the commit title:
-        // let mut commit_author_name = String::new();
-        // let mut commit_datetime = String::new();
+
         if let Ok(output) = Command::new("git")
-            .args(["show", "-s", "--format=%s%n%b%n--AUTHOR--%n%an%n--DATE--%n%cd", "--date=local", commit_hash])
+            .args([
+                "show",
+                "-s",
+                "--format=%s%n%b%n--AUTHOR--%n%an%n--DATE--%n%cd",
+                "--date=local",
+                commit_hash,
+            ])
             .output()
         {
             if output.status.success() {
@@ -181,22 +214,27 @@ pub fn get_commit_descriptions(commit_hashes: Vec<String>) -> Vec<Vec<String>> {
                 if let Ok(output_str) = String::from_utf8(output.stdout) {
                     let sections: Vec<&str> = output_str.split("\n--AUTHOR--\n").collect();
                     if sections.len() == 2 {
-                        // Title + description
                         let message = sections[0].trim();
                         let mut lines = message.lines();
                         let commit_title = lines.next().unwrap_or("").trim().to_string();
                         let commit_description = lines.collect::<Vec<_>>().join("\n").trim().to_string();
 
-                        // Author and date
                         let parts: Vec<&str> = sections[1].split("\n--DATE--\n").collect();
                         if parts.len() == 2 {
                             let author_name = parts[0].trim().to_string();
                             let commit_datetime = parts[1].trim().to_string();
+
+                            let commit_url = base_url
+                                .as_ref()
+                                .map(|url| format!("{}{}", url, commit_hash))
+                                .unwrap_or_else(|| "".to_string());
+
                             output_vec.push(vec![
-                                commit_title.clone(),
-                                commit_description.clone(),
+                                commit_title,
+                                commit_description,
                                 author_name,
                                 commit_datetime,
+                                commit_url,
                             ]);
                         }
                     }


### PR DESCRIPTION
This is a must, otherwise users can't go to the commit and check.