### PR TITLE
Remove leftover debug statement in `db.rs`

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -124,7 +124,6 @@ impl DB {
         self.index = 0;
         self.curr_items = 0;
         // Check if self.folder_path exists, cleanup if cleanup is required.
-        println!("Folder path: {}", self.folder_path);
         if cleanup && Path::new(&self.folder_path).exists() {
             // Remove the folder and all its contents
             std::fs::remove_dir_all(&self.folder_path)


### PR DESCRIPTION
This pull request removes an unnecessary `println!` statement left in the `db.rs` file, which was likely used for debugging purposes. This change helps to clean up the codebase and avoid unintended output in production.