### PR TITLE
Handle renames/move commits

### DIFF
--- a/src/git_command_algo.rs
+++ b/src/git_command_algo.rs
@@ -366,13 +366,13 @@ pub fn get_file_rename_history(file_path: String) -> Vec<(String, Option<String>
     }
 
     let stdout_buf = String::from_utf8(output.stdout).unwrap_or_default();
-    let mut lines = stdout_buf.lines();
+    let lines = stdout_buf.lines();
     let mut last_rename_commit: Option<String> = None;
 
     // Track the current path we're following
     history.push((current_path.clone(), None));
 
-    while let Some(line) = lines.next() {
+    for line in lines {
         let line = line.trim();
 
         // Check if this is a commit hash line

--- a/src/git_command_algo.rs
+++ b/src/git_command_algo.rs
@@ -7,10 +7,15 @@ use crate::git_command_algo;
 use std::collections::{HashMap, HashSet};
 use std::process::{Command, Stdio};
 
-pub fn print_all_valid_directories(
-    workspace_dir: String,
-    gitignore_file_name: Option<String>,
-) {
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileRename {
+    pub old_path: String,
+    pub new_path: String,
+    pub commit_hash: String,
+    pub similarity: u32,
+}
+
+pub fn print_all_valid_directories(workspace_dir: String, gitignore_file_name: Option<String>) {
     // Prints all the valid files to stdout - used by plugins
     // optionally to get files that are to be indexed.
     // if gitignore_file_name.is_none() {
@@ -116,7 +121,6 @@ pub fn get_files_changed(commit_hash: &str) -> Vec<String> {
     files_changed
 }
 
-
 pub async fn index_some_commits(
     origin_file_path: String,
     commits_to_index: Vec<String>,
@@ -125,8 +129,29 @@ pub async fn index_some_commits(
     // First get all the commit hashes that ever touched the given file path.
     let mut map: HashMap<u32, Vec<diff_v2::LineDetail>> = HashMap::new();
     let mut parent_commit_hash: String = String::from("");
+    let mut current_file_path = origin_file_path.clone();
+
     for commit_hash in commits_to_index.iter() {
-        diff_v2::extract_commit_hashes(&parent_commit_hash, commit_hash, &mut map, origin_file_path.as_str());
+        // Check if this commit contains a rename for our current file
+        if let Some(rename) = detect_rename_in_commit(commit_hash, &current_file_path) {
+            // Process the diff with the new path
+            diff_v2::extract_commit_hashes(
+                &parent_commit_hash,
+                commit_hash,
+                &mut map,
+                current_file_path.as_str(),
+            );
+            // Update current path to the old path for subsequent commits
+            current_file_path = rename.old_path.clone();
+        } else {
+            // Normal commit, no rename
+            diff_v2::extract_commit_hashes(
+                &parent_commit_hash,
+                commit_hash,
+                &mut map,
+                current_file_path.as_str(),
+            );
+        }
         parent_commit_hash = commit_hash.clone();
     }
     // Map has populated "relevant commit hashes" for each line.
@@ -154,8 +179,29 @@ pub async fn extract_details_parallel(file_path: String) -> HashMap<u32, AuthorD
     let commit_hashes = git_command_algo::get_all_commits_for_file(file_path.clone());
     let mut map: HashMap<u32, Vec<diff_v2::LineDetail>> = HashMap::new();
     let mut parent_commit_hash: String = String::from("");
+    let mut current_file_path = file_path.clone();
+
     for commit_hash in commit_hashes.iter() {
-        diff_v2::extract_commit_hashes(&parent_commit_hash, commit_hash, &mut map, file_path.as_str());
+        // Check if this commit contains a rename for our current file
+        if let Some(rename) = detect_rename_in_commit(commit_hash, &current_file_path) {
+            // Process the diff with the new path
+            diff_v2::extract_commit_hashes(
+                &parent_commit_hash,
+                commit_hash,
+                &mut map,
+                current_file_path.as_str(),
+            );
+            // Update current path to the old path for subsequent commits
+            current_file_path = rename.old_path.clone();
+        } else {
+            // Normal commit, no rename
+            diff_v2::extract_commit_hashes(
+                &parent_commit_hash,
+                commit_hash,
+                &mut map,
+                current_file_path.as_str(),
+            );
+        }
         parent_commit_hash = commit_hash.clone();
     }
     // Map has populated "relevant commit hashes" for each line.
@@ -263,10 +309,148 @@ pub async fn extract_details_parallel(file_path: String) -> HashMap<u32, AuthorD
     auth_details_map
 }
 
+/// Detects if a file was renamed in a specific commit
+/// Returns Some(FileRename) if a rename was detected, None otherwise
+pub fn detect_rename_in_commit(commit_hash: &str, file_path: &str) -> Option<FileRename> {
+    let mut command = Command::new("git");
+    command.args([
+        "show",
+        "--name-status",
+        "-M",
+        "--pretty=format:",
+        commit_hash,
+        "--",
+    ]);
+
+    let output = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout_buf = String::from_utf8(output.stdout).ok()?;
+
+    // Parse the output for rename status
+    // Format: R<similarity>\told_path\tnew_path
+    for line in stdout_buf.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Check if this is a rename line (starts with R followed by a number)
+        if line.starts_with('R') {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() != 3 {
+                continue;
+            }
+
+            let status = parts[0];
+            let old_path = parts[1];
+            let new_path = parts[2];
+
+            // Check if this rename affects our file
+            if new_path == file_path {
+                // Extract similarity percentage
+                let similarity_str = status.trim_start_matches('R');
+                let similarity = similarity_str.parse::<u32>().unwrap_or(100);
+
+                return Some(FileRename {
+                    old_path: old_path.to_string(),
+                    new_path: new_path.to_string(),
+                    commit_hash: commit_hash.to_string(),
+                    similarity,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+/// Gets all file path history for a file, following renames
+/// Returns a vector of (file_path, starting_commit) tuples in chronological order
+pub fn get_file_rename_history(file_path: String) -> Vec<(String, Option<String>)> {
+    let mut history = vec![];
+    let mut current_path = file_path.clone();
+
+    // Get all commits using --follow flag
+    let mut command = Command::new("git");
+    command.args([
+        "log",
+        "--follow",
+        "--name-status",
+        "-M",
+        "--pretty=format:%h",
+        "--",
+        &current_path,
+    ]);
+
+    let output = match command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => return vec![(file_path, None)],
+    };
+
+    if !output.status.success() {
+        return vec![(file_path, None)];
+    }
+
+    let stdout_buf = String::from_utf8(output.stdout).unwrap_or_default();
+    let mut lines = stdout_buf.lines();
+    let mut last_rename_commit: Option<String> = None;
+
+    // Track the current path we're following
+    history.push((current_path.clone(), None));
+
+    while let Some(line) = lines.next() {
+        let line = line.trim();
+
+        // Check if this is a commit hash line
+        if !line.is_empty()
+            && !line.starts_with('R')
+            && !line.starts_with('A')
+            && !line.starts_with('M')
+            && !line.starts_with('D')
+        {
+            last_rename_commit = Some(line.to_string());
+            continue;
+        }
+
+        // Check for rename status
+        if line.starts_with('R') {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() == 3 {
+                let old_path = parts[1];
+                let new_path = parts[2];
+
+                // If we found a rename for our current path
+                if new_path == current_path {
+                    // Add the old path to history
+                    history.push((old_path.to_string(), last_rename_commit.clone()));
+                    current_path = old_path.to_string();
+                }
+            }
+        }
+    }
+
+    // Reverse to get chronological order (oldest first)
+    history.reverse();
+    history
+}
+
 pub fn get_all_commits_for_file(file_path: String) -> Vec<String> {
     let mut command = Command::new("git");
     command.args([
         "log",
+        "--follow", // Follow renames
         "--pretty=format:%h",
         "--reverse",
         "--",
@@ -290,7 +474,13 @@ pub fn get_all_commits_for_file(file_path: String) -> Vec<String> {
     }
     // Add the last commit hash as well, which is the current state of the file.
     let mut command = Command::new("git");
-    command.args(["log", "--pretty=format:%h", "--", file_path.as_str()]);
+    command.args([
+        "log",
+        "--follow",
+        "--pretty=format:%h",
+        "--",
+        file_path.as_str(),
+    ]);
     let output = command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/git_command_algo.rs
+++ b/src/git_command_algo.rs
@@ -336,6 +336,7 @@ pub fn detect_rename_in_commit(commit_hash: &str, file_path: &str) -> Option<Fil
 
 /// Gets all file path history for a file, following renames
 /// Returns a vector of (file_path, starting_commit) tuples in chronological order
+#[allow(dead_code)]
 pub fn get_file_rename_history(file_path: String) -> Vec<(String, Option<String>)> {
     let mut history = vec![];
     let mut current_path = file_path.clone();

--- a/tests/rename_detection.rs
+++ b/tests/rename_detection.rs
@@ -1,0 +1,392 @@
+// Tests for file rename/move detection functionality
+use contextpilot::git_command_algo::{
+    FileRename, detect_rename_in_commit, get_file_rename_history,
+};
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[cfg(test)]
+mod tests_rename_detection {
+    use super::*;
+
+    /// Helper to save and restore current directory
+    struct DirGuard {
+        original_dir: PathBuf,
+    }
+
+    impl DirGuard {
+        fn new() -> Self {
+            Self {
+                original_dir: std::env::current_dir().expect("Failed to get current dir"),
+            }
+        }
+    }
+
+    impl Drop for DirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original_dir);
+        }
+    }
+
+    /// Helper function to create a test git repository with a renamed file
+    fn setup_test_repo_with_rename() -> TempDir {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let repo_path = temp_dir.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to init git repo");
+
+        // Configure git user
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.name");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.email");
+
+        // Create initial file
+        let file_path = repo_path.join("old_file.rs");
+        std::fs::write(
+            &file_path,
+            "fn main() {\n    println!(\"Hello, world!\");\n}\n",
+        )
+        .expect("Failed to write file");
+
+        Command::new("git")
+            .args(["add", "old_file.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // Rename the file
+        Command::new("git")
+            .args(["mv", "old_file.rs", "new_file.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Rename file"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit rename");
+
+        temp_dir
+    }
+
+    /// Helper function to get the latest commit hash
+    fn get_latest_commit(repo_path: &std::path::Path) -> String {
+        let output = Command::new("git")
+            .args(["rev-parse", "--short=7", "HEAD"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to get commit hash");
+
+        String::from_utf8(output.stdout)
+            .expect("Invalid UTF-8")
+            .trim()
+            .to_string()
+    }
+
+    #[test]
+    fn test_detect_rename_in_commit_basic() {
+        let _guard = DirGuard::new();
+
+        let temp_dir = setup_test_repo_with_rename();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let commit_hash = get_latest_commit(repo_path);
+        let result = detect_rename_in_commit(&commit_hash, "new_file.rs");
+
+        assert!(result.is_some(), "Should detect rename");
+
+        let rename = result.unwrap();
+        assert_eq!(rename.old_path, "old_file.rs");
+        assert_eq!(rename.new_path, "new_file.rs");
+        assert_eq!(rename.similarity, 100);
+        assert_eq!(rename.commit_hash, commit_hash);
+    }
+
+    #[test]
+    fn test_detect_rename_no_rename() {
+        let _guard = DirGuard::new();
+
+        let temp_dir = setup_test_repo_with_rename();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        // Get the first commit (before rename)
+        let output = Command::new("git")
+            .args(["rev-list", "--max-parents=0", "HEAD"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to get first commit");
+
+        let first_commit = String::from_utf8(output.stdout)
+            .expect("Invalid UTF-8")
+            .trim()
+            .to_string();
+
+        let result = detect_rename_in_commit(&first_commit[..7], "old_file.rs");
+        assert!(
+            result.is_none(),
+            "Should not detect rename in initial commit"
+        );
+    }
+
+    #[test]
+    fn test_get_file_rename_history_basic() {
+        let _guard = DirGuard::new();
+
+        let temp_dir = setup_test_repo_with_rename();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let history = get_file_rename_history("new_file.rs".to_string());
+
+        // Should have at least 1 entry
+        assert!(
+            history.len() >= 1,
+            "History should contain at least the current path"
+        );
+
+        // The chronologically first entry should be the old path
+        if history.len() > 1 {
+            assert_eq!(
+                history[0].0, "old_file.rs",
+                "First entry should be old_file.rs"
+            );
+            assert_eq!(
+                history[history.len() - 1].0,
+                "new_file.rs",
+                "Last entry should be new_file.rs"
+            );
+        }
+    }
+
+    #[test]
+    fn test_multiple_renames() {
+        let _guard = DirGuard::new();
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let repo_path = temp_dir.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to init git repo");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.name");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.email");
+
+        // Create initial file
+        std::fs::write(repo_path.join("file_v1.rs"), "fn main() {}\n")
+            .expect("Failed to write file");
+
+        Command::new("git")
+            .args(["add", "file_v1.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // First rename
+        Command::new("git")
+            .args(["mv", "file_v1.rs", "file_v2.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename file");
+
+        Command::new("git")
+            .args(["commit", "-m", "First rename"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // Second rename
+        Command::new("git")
+            .args(["mv", "file_v2.rs", "file_v3.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Second rename"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let history = get_file_rename_history("file_v3.rs".to_string());
+
+        // Should track through all renames
+        assert!(
+            history.len() >= 1,
+            "Should have at least one path in history"
+        );
+
+        // Check if we can find the original file name
+        let has_v1 = history.iter().any(|(path, _)| path == "file_v1.rs");
+        let has_v3 = history.iter().any(|(path, _)| path == "file_v3.rs");
+
+        if history.len() > 1 {
+            assert!(
+                has_v1 || has_v3,
+                "Should contain either original or final filename"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rename_with_content_change() {
+        let _guard = DirGuard::new();
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let repo_path = temp_dir.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to init git repo");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.name");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.email");
+
+        // Create initial file with enough content for similarity detection
+        std::fs::write(
+            repo_path.join("before.rs"),
+            "// Utility module\n\
+            fn helper1() {\n    println!(\"helper1\");\n}\n\n\
+            fn helper2() {\n    println!(\"helper2\");\n}\n\n\
+            fn helper3() {\n    println!(\"helper3\");\n}\n\n\
+            fn helper4() {\n    println!(\"helper4\");\n}\n",
+        )
+        .expect("Failed to write file");
+
+        Command::new("git")
+            .args(["add", "before.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // Rename and modify the file
+        Command::new("git")
+            .args(["mv", "before.rs", "after.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename file");
+
+        // Modify content slightly - change just the comment to keep similarity high
+        std::fs::write(
+            repo_path.join("after.rs"),
+            "// Helper module\n\
+            fn helper1() {\n    println!(\"helper1\");\n}\n\n\
+            fn helper2() {\n    println!(\"helper2\");\n}\n\n\
+            fn helper3() {\n    println!(\"helper3\");\n}\n\n\
+            fn helper4() {\n    println!(\"helper4\");\n}\n",
+        )
+        .expect("Failed to write file");
+
+        Command::new("git")
+            .args(["add", "after.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add modified file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Rename and modify"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let commit_hash = get_latest_commit(repo_path);
+        let result = detect_rename_in_commit(&commit_hash, "after.rs");
+
+        // Git should detect this as a rename since most content is similar
+        assert!(
+            result.is_some(),
+            "Should detect rename with minor content changes"
+        );
+
+        if let Some(rename) = result {
+            assert_eq!(rename.old_path, "before.rs");
+            assert_eq!(rename.new_path, "after.rs");
+            // Similarity should be high since we only changed one line
+            assert!(
+                rename.similarity >= 50,
+                "Similarity should be at least 50% (Git's default threshold)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_rename_wrong_file() {
+        let _guard = DirGuard::new();
+
+        let temp_dir = setup_test_repo_with_rename();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let commit_hash = get_latest_commit(repo_path);
+        let result = detect_rename_in_commit(&commit_hash, "nonexistent_file.rs");
+
+        assert!(result.is_none(), "Should not detect rename for wrong file");
+    }
+}

--- a/tests/rename_detection.rs
+++ b/tests/rename_detection.rs
@@ -1,7 +1,5 @@
 // Tests for file rename/move detection functionality
-use contextpilot::git_command_algo::{
-    FileRename, detect_rename_in_commit, get_file_rename_history,
-};
+use contextpilot::git_command_algo::{detect_rename_in_commit, get_file_rename_history};
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
@@ -166,7 +164,7 @@ mod tests_rename_detection {
 
         // Should have at least 1 entry
         assert!(
-            history.len() >= 1,
+            !history.is_empty(),
             "History should contain at least the current path"
         );
 
@@ -258,7 +256,7 @@ mod tests_rename_detection {
 
         // Should track through all renames
         assert!(
-            history.len() >= 1,
+            !history.is_empty(),
             "Should have at least one path in history"
         );
 

--- a/tests/rename_integration.rs
+++ b/tests/rename_integration.rs
@@ -153,7 +153,7 @@ pub fn divide(a: i32, b: i32) -> i32 {\n\
             "Should have at least 4 commits (including pre-rename history)"
         );
 
-        println!("Found commits: {:?}", commits);
+        println!("Found commits: {commits:?}");
 
         // Verify we can trace back to the original file
         // The commits should include those that touched utils.rs before the rename
@@ -169,7 +169,7 @@ pub fn divide(a: i32, b: i32) -> i32 {\n\
         // Get all commits
         let commits = get_all_commits_for_file("math_utils.rs".to_string());
 
-        println!("Commits to index: {:?}", commits);
+        println!("Commits to index: {commits:?}");
 
         // Index all commits
         let auth_details = index_some_commits("math_utils.rs".to_string(), commits).await;
@@ -188,8 +188,7 @@ pub fn divide(a: i32, b: i32) -> i32 {\n\
             );
             assert!(
                 !details.commit_hashes.is_empty(),
-                "Line {} should have at least one commit",
-                line_num
+                "Line {line_num} should have at least one commit"
             );
         }
     }
@@ -250,7 +249,7 @@ pub fn divide(a: i32, b: i32) -> i32 {\n\
                     "blame",
                     latest_commit,
                     "-L",
-                    &format!("{},{}", line_num, line_num),
+                    &format!("{line_num},{line_num}"),
                     "--abbrev=7",
                     "--",
                     "math_utils.rs",
@@ -310,8 +309,7 @@ pub fn divide(a: i32, b: i32) -> i32 {\n\
         let accuracy = (match_count as f64 / total_count as f64) * 100.0;
         assert!(
             accuracy >= 80.0,
-            "Accuracy should be at least 80%, got {:.2}%",
-            accuracy
+            "Accuracy should be at least 80%, got {accuracy:.2}%"
         );
     }
 

--- a/tests/rename_integration.rs
+++ b/tests/rename_integration.rs
@@ -1,0 +1,402 @@
+// Integration tests for file rename/move detection with full indexing workflow
+use contextpilot::git_command_algo::{get_all_commits_for_file, index_some_commits};
+use std::process::Command;
+use tempfile::TempDir;
+
+#[cfg(test)]
+mod tests_rename_integration {
+    use super::*;
+
+    /// Helper to create a comprehensive test repository
+    fn setup_comprehensive_test_repo() -> TempDir {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let repo_path = temp_dir.path();
+
+        // Initialize git repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to init git repo");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.name");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user.email");
+
+        // Commit 1: Create initial file with some content
+        std::fs::write(
+            repo_path.join("utils.rs"),
+            "// Utility functions\n\
+pub fn add(a: i32, b: i32) -> i32 {\n\
+    a + b\n\
+}\n\
+\n\
+pub fn subtract(a: i32, b: i32) -> i32 {\n\
+    a - b\n\
+}\n",
+        )
+        .expect("Failed to write initial file");
+
+        Command::new("git")
+            .args(["add", "utils.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Add utility functions"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // Commit 2: Modify the file (add a function)
+        std::fs::write(
+            repo_path.join("utils.rs"),
+            "// Utility functions\n\
+pub fn add(a: i32, b: i32) -> i32 {\n\
+    a + b\n\
+}\n\
+\n\
+pub fn subtract(a: i32, b: i32) -> i32 {\n\
+    a - b\n\
+}\n\
+\n\
+pub fn multiply(a: i32, b: i32) -> i32 {\n\
+    a * b\n\
+}\n",
+        )
+        .expect("Failed to write modified file");
+
+        Command::new("git")
+            .args(["add", "utils.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add modified file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Add multiply function"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // Commit 3: Rename the file
+        Command::new("git")
+            .args(["mv", "utils.rs", "math_utils.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Rename utils.rs to math_utils.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit rename");
+
+        // Commit 4: Modify after rename
+        std::fs::write(
+            repo_path.join("math_utils.rs"),
+            "// Math utility functions\n\
+pub fn add(a: i32, b: i32) -> i32 {\n\
+    a + b\n\
+}\n\
+\n\
+pub fn subtract(a: i32, b: i32) -> i32 {\n\
+    a - b\n\
+}\n\
+\n\
+pub fn multiply(a: i32, b: i32) -> i32 {\n\
+    a * b\n\
+}\n\
+\n\
+pub fn divide(a: i32, b: i32) -> i32 {\n\
+    a / b\n\
+}\n",
+        )
+        .expect("Failed to write file after rename");
+
+        Command::new("git")
+            .args(["add", "math_utils.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add modified file");
+
+        Command::new("git")
+            .args(["commit", "-m", "Add divide function"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        temp_dir
+    }
+
+    #[tokio::test]
+    async fn test_get_all_commits_follows_renames() {
+        let temp_dir = setup_comprehensive_test_repo();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        // Get all commits for the renamed file
+        let commits = get_all_commits_for_file("math_utils.rs".to_string());
+
+        // Should include commits from before the rename
+        assert!(
+            commits.len() >= 4,
+            "Should have at least 4 commits (including pre-rename history)"
+        );
+
+        println!("Found commits: {:?}", commits);
+
+        // Verify we can trace back to the original file
+        // The commits should include those that touched utils.rs before the rename
+    }
+
+    #[tokio::test]
+    async fn test_index_some_commits_with_rename() {
+        let temp_dir = setup_comprehensive_test_repo();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        // Get all commits
+        let commits = get_all_commits_for_file("math_utils.rs".to_string());
+
+        println!("Commits to index: {:?}", commits);
+
+        // Index all commits
+        let auth_details = index_some_commits("math_utils.rs".to_string(), commits).await;
+
+        // Should have indexed lines from the file
+        assert!(!auth_details.is_empty(), "Should have indexed some lines");
+
+        println!("Indexed {} lines", auth_details.len());
+
+        // Verify that we have commit history for lines
+        for (line_num, details) in auth_details.iter() {
+            println!(
+                "Line {}: {:?} commits",
+                line_num,
+                details.commit_hashes.len()
+            );
+            assert!(
+                !details.commit_hashes.is_empty(),
+                "Line {} should have at least one commit",
+                line_num
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_line_history_across_rename() {
+        let temp_dir = setup_comprehensive_test_repo();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let commits = get_all_commits_for_file("math_utils.rs".to_string());
+        let auth_details = index_some_commits("math_utils.rs".to_string(), commits.clone()).await;
+
+        // The `add` function should have commits from before the rename
+        // Line 2-4 contains the add function
+        let add_function_lines: Vec<_> = auth_details
+            .iter()
+            .filter(|(line_num, _)| **line_num >= 2 && **line_num <= 4)
+            .collect();
+
+        assert!(
+            !add_function_lines.is_empty(),
+            "Should find add function lines"
+        );
+
+        // Check that at least one line has commit history
+        let has_history = add_function_lines
+            .iter()
+            .any(|(_, details)| !details.commit_hashes.is_empty());
+
+        assert!(
+            has_history,
+            "Add function should have commit history from before rename"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_accuracy_with_git_blame_across_rename() {
+        let temp_dir = setup_comprehensive_test_repo();
+        let repo_path = temp_dir.path();
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let commits = get_all_commits_for_file("math_utils.rs".to_string());
+        let auth_details = index_some_commits("math_utils.rs".to_string(), commits.clone()).await;
+
+        // Get the latest commit for blame comparison
+        let latest_commit = commits.last().expect("Should have commits");
+
+        let mut total_count = 0;
+        let mut match_count = 0;
+
+        for (line_num, details) in auth_details.iter() {
+            // Get git blame for this line
+            let output = Command::new("git")
+                .args([
+                    "blame",
+                    latest_commit,
+                    "-L",
+                    &format!("{},{}", line_num, line_num),
+                    "--abbrev=7",
+                    "--",
+                    "math_utils.rs",
+                ])
+                .current_dir(repo_path)
+                .output()
+                .expect("Failed to run git blame");
+
+            if !output.status.success() {
+                continue;
+            }
+
+            let stdout = String::from_utf8(output.stdout).unwrap_or_default();
+            let first_line = match stdout.lines().next() {
+                Some(line) => line,
+                None => continue,
+            };
+
+            let parts: Vec<&str> = first_line.split_whitespace().collect();
+            if parts.is_empty() {
+                continue;
+            }
+
+            let mut blame_commit = parts[0].to_string();
+
+            // Handle the ^ prefix for boundary commits
+            if blame_commit.starts_with('^') {
+                blame_commit = blame_commit.trim_start_matches('^').to_string();
+            }
+
+            // Ensure we're comparing 7-character hashes
+            if blame_commit.len() > 7 {
+                blame_commit = blame_commit[..7].to_string();
+            }
+
+            total_count += 1;
+
+            // Check if our indexed commits contain the blame commit
+            if details.commit_hashes.contains(&blame_commit) {
+                match_count += 1;
+            } else {
+                println!(
+                    "Line {}: Expected commit {} not found in {:?}",
+                    line_num, blame_commit, details.commit_hashes
+                );
+            }
+        }
+
+        println!(
+            "Accuracy: {}/{} ({:.2}%)",
+            match_count,
+            total_count,
+            (match_count as f64 / total_count as f64) * 100.0
+        );
+
+        // We should have at least 80% accuracy
+        let accuracy = (match_count as f64 / total_count as f64) * 100.0;
+        assert!(
+            accuracy >= 80.0,
+            "Accuracy should be at least 80%, got {:.2}%",
+            accuracy
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_renames_full_workflow() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let repo_path = temp_dir.path();
+
+        // Initialize repo
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to init");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set user.name");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set user.email");
+
+        // Create and commit initial file
+        std::fs::write(
+            repo_path.join("v1.rs"),
+            "pub fn hello() {\n    println!(\"v1\");\n}\n",
+        )
+        .expect("Failed to write");
+
+        Command::new("git")
+            .args(["add", "v1.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to add");
+
+        Command::new("git")
+            .args(["commit", "-m", "v1"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // First rename
+        Command::new("git")
+            .args(["mv", "v1.rs", "v2.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename");
+
+        Command::new("git")
+            .args(["commit", "-m", "rename to v2"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        // Second rename
+        Command::new("git")
+            .args(["mv", "v2.rs", "v3.rs"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to rename");
+
+        Command::new("git")
+            .args(["commit", "-m", "rename to v3"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to commit");
+
+        std::env::set_current_dir(repo_path).expect("Failed to change directory");
+
+        let commits = get_all_commits_for_file("v3.rs".to_string());
+
+        // Should have 3 commits
+        assert_eq!(commits.len(), 3, "Should have 3 commits across all renames");
+
+        let auth_details = index_some_commits("v3.rs".to_string(), commits).await;
+
+        // Should be able to index the file
+        assert!(
+            !auth_details.is_empty(),
+            "Should successfully index renamed file"
+        );
+    }
+}


### PR DESCRIPTION
Adds feature to respect commits with rename>50% similarity + commits like git mv <> <>; Adds integration tests as well.

Done via claude-code [I just ideated and guided how to do it]